### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/112/594/318/9/1125943189.geojson
+++ b/data/112/594/318/9/1125943189.geojson
@@ -28,6 +28,12 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0648\u0641\u064a"
     ],
+    "name:ary_x_preferred":[
+        "\u0623\u0644\u0648\u0641\u064a"
+    ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0648\u0641\u0649"
+    ],
     "name:ast_x_preferred":[
         "Alofi"
     ],
@@ -36,6 +42,9 @@
     ],
     "name:bel_x_preferred":[
         "\u041f\u0430\u0441\u0451\u043b\u0430\u043a \u0410\u043b\u043e\u0444\u0456"
+    ],
+    "name:bel_x_variant":[
+        "\u0410\u043b\u043e\u0444\u0456"
     ],
     "name:ben_x_preferred":[
         "\u0986\u09b2\u09cb\u09ab\u09bf"
@@ -58,8 +67,14 @@
     "name:ces_x_preferred":[
         "Alofi"
     ],
+    "name:chv_x_preferred":[
+        "\u0410\u043b\u043e\u0444\u0438"
+    ],
     "name:ckb_x_preferred":[
         "\u0626\u06d5\u0644\u06c6\u0641\u06cc"
+    ],
+    "name:cym_x_preferred":[
+        "Alofi"
     ],
     "name:dan_x_preferred":[
         "Alofi"
@@ -127,6 +142,9 @@
     "name:ind_x_preferred":[
         "Alofi"
     ],
+    "name:isl_x_preferred":[
+        "Alofi"
+    ],
     "name:ita_x_preferred":[
         "Alofi"
     ],
@@ -143,6 +161,9 @@
         "Alofi"
     ],
     "name:lav_x_preferred":[
+        "Alofi"
+    ],
+    "name:lij_x_preferred":[
         "Alofi"
     ],
     "name:lit_x_preferred":[
@@ -190,6 +211,9 @@
     "name:por_x_preferred":[
         "Alofi"
     ],
+    "name:pus_x_preferred":[
+        "\u0627\u0644\u0648\u0641\u064a"
+    ],
     "name:ron_x_preferred":[
         "Alofi"
     ],
@@ -226,11 +250,17 @@
     "name:swe_x_preferred":[
         "Alofi"
     ],
+    "name:szl_x_preferred":[
+        "Alofi"
+    ],
     "name:tah_x_preferred":[
         "Alofi"
     ],
     "name:tam_x_preferred":[
         "\u0b85\u0bb2\u0bcb\u0b83\u0baa\u0bbf"
+    ],
+    "name:tgk_x_preferred":[
+        "\u0410\u043b\u043e\u0444\u0438"
     ],
     "name:tha_x_preferred":[
         "\u0e2d\u0e32\u0e42\u0e25\u0e1f\u0e35"
@@ -252,6 +282,9 @@
     ],
     "name:war_x_preferred":[
         "Alofi"
+    ],
+    "name:wuu_x_preferred":[
+        "\u963f\u6d1b\u83f2"
     ],
     "name:yue_x_preferred":[
         "\u963f\u6d1b\u83f2"
@@ -299,7 +332,7 @@
         }
     ],
     "wof:id":1125943189,
-    "wof:lastmodified":1636495064,
+    "wof:lastmodified":1690849801,
     "wof:name":"Alofi",
     "wof:parent_id":85681315,
     "wof:placetype":"locality",

--- a/data/112/601/020/7/1126010207.geojson
+++ b/data/112/601/020/7/1126010207.geojson
@@ -46,6 +46,9 @@
     "name:jpn_x_preferred":[
         "\u30c8\u30a5\u30a2\u30d1"
     ],
+    "name:nan_x_preferred":[
+        "Tuapa"
+    ],
     "name:nld_x_preferred":[
         "Tuapa"
     ],
@@ -57,6 +60,9 @@
     ],
     "name:spa_x_preferred":[
         "Tuapa"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0422\u0443\u0430\u043f\u0430"
     ],
     "qs_pg:aaroncc":"NU",
     "qs_pg:gn_country":"NU",
@@ -91,7 +97,7 @@
         }
     ],
     "wof:id":1126010207,
-    "wof:lastmodified":1566672071,
+    "wof:lastmodified":1690849801,
     "wof:name":"Tuapa",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/429/419/890429419.geojson
+++ b/data/890/429/419/890429419.geojson
@@ -22,6 +22,9 @@
     "name:dan_x_preferred":[
         "Namukulu"
     ],
+    "name:deu_x_preferred":[
+        "Namukulu"
+    ],
     "name:eng_x_preferred":[
         "Namukulu"
     ],
@@ -34,6 +37,9 @@
     "name:jpn_x_preferred":[
         "\u30ca\u30e0\u30af\u30eb"
     ],
+    "name:nan_x_preferred":[
+        "Namukulu"
+    ],
     "name:nld_x_preferred":[
         "Namukulu"
     ],
@@ -45,6 +51,9 @@
     ],
     "name:spa_x_preferred":[
         "Namukulu"
+    ],
+    "name:ukr_x_preferred":[
+        "\u041d\u0430\u043c\u0443\u043a\u0443\u043b\u0443"
     ],
     "name:zho_x_preferred":[
         "\u5927\u6751"
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":890429419,
-    "wof:lastmodified":1566672070,
+    "wof:lastmodified":1690849800,
     "wof:name":"Mamakula",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/429/421/890429421.geojson
+++ b/data/890/429/421/890429421.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:deu_x_preferred":[
+        "Makefu"
+    ],
     "name:eng_x_preferred":[
         "Makefu"
     ],
@@ -31,6 +34,12 @@
     "name:jpn_x_preferred":[
         "\u30de\u30b1\u30d5"
     ],
+    "name:mkd_x_preferred":[
+        "\u041c\u0430\u043a\u0435\u0444\u0443"
+    ],
+    "name:nan_x_preferred":[
+        "Makefu"
+    ],
     "name:nld_x_preferred":[
         "Makefu"
     ],
@@ -42,6 +51,9 @@
     ],
     "name:spa_x_preferred":[
         "Makefu"
+    ],
+    "name:ukr_x_preferred":[
+        "\u041c\u0430\u043a\u0435\u0444\u0443"
     ],
     "qs:name":"Makefu",
     "qs:photos_9r":0,
@@ -70,7 +82,7 @@
         }
     ],
     "wof:id":890429421,
-    "wof:lastmodified":1566672070,
+    "wof:lastmodified":1690849800,
     "wof:name":"Makefu",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/429/423/890429423.geojson
+++ b/data/890/429/423/890429423.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:deu_x_preferred":[
+        "Liku"
+    ],
     "name:eng_x_preferred":[
         "Liku"
     ],
@@ -34,6 +37,12 @@
     "name:jpn_x_preferred":[
         "\u30ea\u30af"
     ],
+    "name:mkd_x_preferred":[
+        "\u041b\u0438\u043a\u0443"
+    ],
+    "name:nan_x_preferred":[
+        "Liku"
+    ],
     "name:nld_x_preferred":[
         "Liku"
     ],
@@ -48,6 +57,9 @@
     ],
     "name:spa_x_preferred":[
         "Liku"
+    ],
+    "name:ukr_x_preferred":[
+        "\u041b\u0456\u043a\u0443"
     ],
     "qs:name":"Liku",
     "qs:photos_9r":0,
@@ -76,7 +88,7 @@
         }
     ],
     "wof:id":890429423,
-    "wof:lastmodified":1566672070,
+    "wof:lastmodified":1690849800,
     "wof:name":"Liku",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/429/425/890429425.geojson
+++ b/data/890/429/425/890429425.geojson
@@ -37,6 +37,12 @@
     "name:jpn_x_preferred":[
         "\u30e9\u30b1\u30d1"
     ],
+    "name:mkd_x_preferred":[
+        "\u041b\u0430\u043a\u0435\u043f\u0430"
+    ],
+    "name:nan_x_preferred":[
+        "Lakepa"
+    ],
     "name:nld_x_preferred":[
         "Lakepa"
     ],
@@ -48,6 +54,9 @@
     ],
     "name:spa_x_preferred":[
         "Lakepa"
+    ],
+    "name:ukr_x_preferred":[
+        "\u041b\u0430\u043a\u0435\u043f\u0430"
     ],
     "qs:name":"Lakepa",
     "qs:photos_9r":0,
@@ -76,7 +85,7 @@
         }
     ],
     "wof:id":890429425,
-    "wof:lastmodified":1566672070,
+    "wof:lastmodified":1690849800,
     "wof:name":"Lakepa",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/429/431/890429431.geojson
+++ b/data/890/429/431/890429431.geojson
@@ -43,6 +43,9 @@
     "name:jpn_x_preferred":[
         "\u30cf\u30af\u30d7"
     ],
+    "name:nan_x_preferred":[
+        "Hakupu"
+    ],
     "name:nld_x_preferred":[
         "Hakupu"
     ],
@@ -55,8 +58,14 @@
     "name:spa_x_preferred":[
         "Hakupu"
     ],
+    "name:ukr_x_preferred":[
+        "\u0425\u0430\u043a\u0443\u043f\u0443"
+    ],
     "name:urd_x_preferred":[
         "\u06c1\u0627\u06a9\u0648\u067e\u0648"
+    ],
+    "name:zho_x_preferred":[
+        "\u54c8\u5e93\u666e"
     ],
     "qs:name":"Hakupu",
     "qs:photos_9r":0,
@@ -92,7 +101,7 @@
         }
     ],
     "wof:id":890429431,
-    "wof:lastmodified":1566672070,
+    "wof:lastmodified":1690849800,
     "wof:name":"Hakupu",
     "wof:parent_id":85681315,
     "wof:placetype":"locality",

--- a/data/890/445/253/890445253.geojson
+++ b/data/890/445/253/890445253.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u0623\u0641\u0627\u062a\u064a\u0644\u064a"
+    ],
     "name:bul_x_preferred":[
         "\u0410\u0432\u0430\u0442\u0435\u043b\u0435"
     ],
@@ -43,6 +46,12 @@
     "name:jpn_x_preferred":[
         "\u30a2\u30d0\u30c6\u30ec"
     ],
+    "name:mal_x_preferred":[
+        "\u0d05\u0d35\u0d24\u0d46\u0d32\u0d46"
+    ],
+    "name:nan_x_preferred":[
+        "Avatele"
+    ],
     "name:nld_x_preferred":[
         "Avatele"
     ],
@@ -60,6 +69,9 @@
     ],
     "name:und_x_variant":[
         "Oneonepata"
+    ],
+    "name:zho_x_preferred":[
+        "\u963f\u74e6\u6cf0\u52d2"
     ],
     "qs:name":"Avatele",
     "qs:photos_9r":0,
@@ -95,7 +107,7 @@
         }
     ],
     "wof:id":890445253,
-    "wof:lastmodified":1566672070,
+    "wof:lastmodified":1690849801,
     "wof:name":"Avatele",
     "wof:parent_id":85681315,
     "wof:placetype":"locality",

--- a/data/890/455/389/890455389.geojson
+++ b/data/890/455/389/890455389.geojson
@@ -25,6 +25,9 @@
     "name:ceb_x_preferred":[
         "Mutalau"
     ],
+    "name:deu_x_preferred":[
+        "Mutalau"
+    ],
     "name:eng_x_preferred":[
         "Mutalau"
     ],
@@ -40,6 +43,9 @@
     "name:jpn_x_preferred":[
         "\u30e0\u30bf\u30e9\u30a6"
     ],
+    "name:nan_x_preferred":[
+        "Mutalau"
+    ],
     "name:nld_x_preferred":[
         "Mutalau"
     ],
@@ -54,6 +60,9 @@
     ],
     "name:spa_x_preferred":[
         "Mutalau"
+    ],
+    "name:ukr_x_preferred":[
+        "\u041c\u0443\u0442\u0430\u043b\u0430\u0443"
     ],
     "qs:name":"Mutalau",
     "qs:photos_9r":0,
@@ -82,7 +91,7 @@
         }
     ],
     "wof:id":890455389,
-    "wof:lastmodified":1566672069,
+    "wof:lastmodified":1690849799,
     "wof:name":"Mutalau",
     "wof:parent_id":-1,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.